### PR TITLE
escape pipe characters in password bank explanation

### DIFF
--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -798,17 +798,17 @@ sections.
     the pipe character are supported through escaping the pipe character
     with a second pipe. Pipes are always escaped left to right.
 
-    > **Example Password Bank:** passw0rd|Trace1234!|aaa|bb|cccc||dd||eee|||ff|||ggg||||hhh|||||
+    > **Example Password Bank:** `passw0rd|Trace1234!|aaa|bb|cccc||dd||eee|||ff|||ggg||||hhh|||||`
     >
     > Yields the following passwords:
     >
-    > * passw0rd
-    > * Tracer1234!
-    > * aaa
-    > * bb
-    > * cccc|dd|eee|
-    > * ff|
-    > * ggg||hhh||
+    > * `passw0rd`
+    > * `Trace1234!`
+    > * `aaa`
+    > * `bb`
+    > * `cccc|dd|eee|`
+    > * `ff|`
+    > * `ggg||hhh||`
 
 - **Extraction Thread Count:** The number of documents to extract in parallel.
 


### PR DESCRIPTION
This hopefully escapes the pipes used in our password bank example.

Currently, they are being rendered as a table, which we obviously don't want.

Unfortunately, the .md renderer used for our actual site is different than the in-Github preview. I'll need this merged to master to test whether this is a sufficient escape, if not, there are other things I can try.