### PR TITLE
INSIGHT-1714 timeout of data batch goes through automatic retry

### DIFF
--- a/docs/user_documentation.md
+++ b/docs/user_documentation.md
@@ -1352,8 +1352,8 @@ Data Batch objects have associated Mass Operations (and corresponding Data Batch
 
 > **NOTE: ** If a Data Batch sits in a status other than `Completed`, `CompletedWithErrors`, `CompletedWithDocumentLevelErrors`, or `Abandoned` for longer than 24 hours (timeout configurable with the `Data Batch Timeout In Hours` setting on the Data Validation Task), it will automatically be:
 >
-> * Retried if it is in the `Enriching` status and has not yet been retried, exactly as if the Trace Data Batch Retry action was used (Data Batches can hang in the Enriching status and this reduces the number of Data Batches that must be retried manually)
-> * Marked `CompletedWithErrors` if the Data Batch has files and could be retried
+> * Retried if automatic retry is configured for workspace and retry attempts exist for the stuck data batch (Data Batches can hang in the Enriching status and this reduces the number of Data Batches that must be retried manually)
+> * Marked `CompletedWithErrors` if the Data Batch exhausted its retry attempts and the error was unable to be resolved
 > * Marked `Abandoned` if the Data Batch does not have any files 
 >
 > This functionality helps ensure that temporary system issues do not lead to Data Batches being stuck indefinitely containing documents that never make it into the workspace.


### PR DESCRIPTION
timeout of a data batch now goes through automatic retry (if files exists, else goes to abandon)