### PR TITLE
Installing and configuring Data Source - remove Aip Application and T…

### DIFF
--- a/docs/administrator_guide/collection/general_data_source_information/installing_and_configuring_Trace_data_sources.md
+++ b/docs/administrator_guide/collection/general_data_source_information/installing_and_configuring_Trace_data_sources.md
@@ -114,8 +114,6 @@ To configure the Trace data source, perform the following steps. See the [Data S
    - Discover Monitored Individual
    - Include Monitored Individuals Not Linked To Data Source
    - Discover Monitored Individuals Ignore Case
-   - Aip Application Id - not used.
-   - Aip Tenant Id -  not used.
    - Last Error Retention In Hours
    - Excluded File Transformation Enabled.
 


### PR DESCRIPTION
…enant Id

These were removed from Collect Data Sources:
   - Aip Application Id - not used.
   - Aip Tenant Id -  not used.

Issue - there is Product inconsistency - these parameters are still available on Globanet Data Sources (I didn't check all). They should be removed from ALL Data Sources.