### PR TITLE
O365 Mail - RSMF metadata mappings must have ":" at the end

### DIFF
--- a/docs/administrator_guide/collection/all_data_sources/chat_data_sources/microsoft_office_365_teams_chat_via_collect.md
+++ b/docs/administrator_guide/collection/all_data_sources/chat_data_sources/microsoft_office_365_teams_chat_via_collect.md
@@ -116,9 +116,9 @@ The following table lists metadata captured by this data source:
 | FROM                   | The first person to send a message in that respective slice  |
 | TO                     | Chat attendees                                               |
 | CONVERSATION-ID        | Unique identifier - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
-| X-RSMF-EndDate         | End date of the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
-| X-RSMF-MessageCount    | Number of messages in the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
-| X-RSMF-AttachmentCount | Number of attachments in the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
+| X-RSMF-EndDate:         | End date of the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
+| X-RSMF-MessageCount:    | Number of messages in the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
+| X-RSMF-AttachmentCount: | Number of attachments in the chat/slice - when creating a data mapping, set **Read From Other Metadata Column** to Yes. |
 
 A "Slice" of data refers to a start and end time of data that will be captured in one Relativity Document. Unless specified, a slice will contain one days worth of data.
 {: .info}


### PR DESCRIPTION
These Data Mappings must be literary with ":" end the end. W/o ":" a Data Mapping won't work! This is due to OI issue.
"X-RSMF-EndDate:"
"X-RSMF-MessageCount:"
"X-RSMF-AttachmentCount:"

This applies to all RSMF type connectors.